### PR TITLE
Fix longtable undefined theHtable issue

### DIFF
--- a/_extensions/presentation/beamer/before-title.tex
+++ b/_extensions/presentation/beamer/before-title.tex
@@ -25,3 +25,6 @@ $endif$
 
 % Find images
 \graphicspath{{_extensions/presentation/_images/background/}{_extensions/quarto-monash/presentation/_images/background/}{figs/}{figures/}{images/}{img/}}
+
+% Fix longtable undefined theHtable issue
+\newcommand{\theHtable}{\thetable}


### PR DESCRIPTION
When rendering the template, I encountered the following error with the table
```
Undefined control sequence. 
\@currentHref ->table.\theHtable
```
The problem seems to appear after TeX Live 2024.
This pull request fixes it. 

See https://github.com/quarto-dev/quarto-cli/issues/10019