### PR TITLE
Treat both cases: theHtable is now defined somehow

### DIFF
--- a/_extensions/presentation/beamer/before-title.tex
+++ b/_extensions/presentation/beamer/before-title.tex
@@ -11,7 +11,7 @@ $endif$
 
 % Monash title page
 % One can alter the font size by setting eg 'titlefontsize: 20pt' in the YAML header
-\setbeamerfont{title}{series=\bfseries,parent=structure,size=\fontsize{22}{28}}
+\setbeamerfont{title}{series=\bfseries,parent=structure,size=\fontsize{$if(titlefontsize)$$titlefontsize$$else$22$endif$}{28}}
 \setbeamertemplate{title page}
 {\placefig{-0.01}{-0.01}{width=1.01\paperwidth,height=1.01\paperheight}{$titlegraphic$}
 \begin{textblock}{8.7}(1,2.8)\usebeamerfont{title}

--- a/_extensions/presentation/beamer/before-title.tex
+++ b/_extensions/presentation/beamer/before-title.tex
@@ -27,4 +27,6 @@ $endif$
 \graphicspath{{_extensions/presentation/_images/background/}{_extensions/quarto-monash/presentation/_images/background/}{figs/}{figures/}{images/}{img/}}
 
 % Fix longtable undefined theHtable issue
-\newcommand{\theHtable}{\thetable}
+\makeatletter
+\@ifundefined{\theHtable}{\renewcommand{\theHtable}{\thetable}}{}
+\makeatother


### PR DESCRIPTION
Apparently the issue with theHtable is fixed at one point because now I am getting with my patch
```
LaTeX Error: Command \theHtable already defined.
```

I couldn't find when this is fixed and where, so just in case I try to make it work for both cases. I am not sure if this is the best way to do it or if it works in the other case (couldn't test it). Need a latex master to have a look.